### PR TITLE
Fix a FMLCommonSetupEvent crash when attempting to load URL Contents Offline

### DIFF
--- a/src/main/java/com/github/alexthe666/citadel/Citadel.java
+++ b/src/main/java/com/github/alexthe666/citadel/Citadel.java
@@ -51,15 +51,15 @@ public class Citadel {
         NETWORK_WRAPPER.registerMessage(packetsRegistered++, PropertiesMessage.class, PropertiesMessage::write, PropertiesMessage::read, PropertiesMessage.Handler::handle);
         BufferedReader urlContents = WebHelper.getURLContents("https://raw.githubusercontent.com/Alex-the-666/Citadel/master/src/main/resources/assets/citadel/patreon.txt", "assets/citadel/patreon.txt");
         if (urlContents != null) {
-            String line = null;
             try {
+                String line;
                 while ((line = urlContents.readLine()) != null) {
                     PATREONS.add(line);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Failed to load patreon contributor perks");
             }
-        }
+        } else LOGGER.warn("Failed to load patreon contributor perks");
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {

--- a/src/main/java/com/github/alexthe666/citadel/web/WebHelper.java
+++ b/src/main/java/com/github/alexthe666/citadel/web/WebHelper.java
@@ -1,49 +1,36 @@
 package com.github.alexthe666.citadel.web;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.util.ResourceLocation;
-
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.*;
-import java.net.MalformedURLException;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 public class WebHelper {
 
     @Nullable
-    public static BufferedReader getURLContents(String urlString, String backupFileLoc){
-        BufferedReader reader = null;
-        boolean useBackup = false;
-        URL url;
+    public static BufferedReader getURLContents(@Nonnull String urlString, @Nonnull String backupFileLoc){
         try {
-            url = new URL(urlString);
-        } catch (MalformedURLException e) {
-            url = null;
-            useBackup = true;
+            URL url = new URL(urlString);
+            URLConnection connection = url.openConnection();
+            InputStream stream = connection.getInputStream();
+            InputStreamReader reader = new InputStreamReader(stream);
+            
+            return new BufferedReader(reader);
+        } catch (Exception e) { // Malformed URL, Offline, etc.
+            e.printStackTrace();
         }
-        if(url != null){
-            URLConnection connection = null;
-            try {
-                connection = url.openConnection();
-                InputStream is = connection.getInputStream();
-                reader = new BufferedReader(new InputStreamReader(is));
-            } catch (IOException e) {
-                e.printStackTrace();
-                useBackup = true;
-            }
+        
+        try { // Backup
+            return new BufferedReader(new InputStreamReader(WebHelper.class.getClass().getClassLoader().getResourceAsStream(backupFileLoc), StandardCharsets.UTF_8));
+        } catch (NullPointerException e) { // Can't parse backupFileLoc
+            e.printStackTrace();
         }
-        if(useBackup){
-            if (WebHelper.class.getClassLoader().getResourceAsStream(backupFileLoc) == null) {
-                backupFileLoc = "assets/citadel/backup_text.txt";
-            }
-            try {
-                reader = new BufferedReader(new InputStreamReader(WebHelper.class.getClass().getClassLoader().getResourceAsStream(backupFileLoc), "UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
-            }
-        }
-        return reader;
+        
+        return null;
     }
 
 }


### PR DESCRIPTION
- Use Cleaner try/catch blocks and catch generic exceptions. If even backup fails to parse, return null and have a null checker on FMLCommonSetupEvent.
- This patches a crash when attempting to load URL Content while offline.